### PR TITLE
Fix typo, cleanup, and basic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install -e .
 
 ## Running DDPO
 ```
-python pipeline/policy_gradient.py --dataset compressed-animals
+python pipeline/policy_gradient.py --dataset compressed_animals
 ```
 
 The `--dataset` flag can be replaced by any of the configs defined in `config/base.py`.

--- a/ddpo/utils/hdf5.py
+++ b/ddpo/utils/hdf5.py
@@ -173,8 +173,8 @@ class H5Writer:
             try:
                 self._file[field][start:end] = x[:]
                 self._sizes[field] += size
-            except:
-                pdb.set_trace()
+            except Exception as e:
+                raise e
 
     def close(self):
         for field, size in self._sizes.items():

--- a/pipeline/policy_gradient.py
+++ b/pipeline/policy_gradient.py
@@ -221,7 +221,7 @@ def main():
     mean_rewards = []  # mean reward for each epoch
     std_rewards = []  # std reward for each epoch
     for epoch in range(args.num_train_epochs):
-        # list of dicts with entires of shape:
+        # list of dicts with entries of shape:
         # (num_devices * sample_batch_size, ...)
         samples = []
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,5 @@
+import pathlib
+
+def test_dataset_name():
+    text = pathlib.Path('README.md').read_text()
+    assert 'compressed_animals' in text


### PR DESCRIPTION
## Summary
- fix typo in policy_gradient comment
- remove leftover debugger in hdf5 writer
- update README dataset example
- add minimal README test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ac7fbcf48322acea6a14e82dc706