### PR TITLE
Remove debugging breakpoint from H5Writer

### DIFF
--- a/ddpo/utils/hdf5.py
+++ b/ddpo/utils/hdf5.py
@@ -15,7 +15,6 @@ from collections import defaultdict
 from datetime import datetime
 from google.cloud import storage
 from PIL import Image
-import pdb
 
 from ddpo import utils
 from .serialization import mkdir
@@ -173,8 +172,10 @@ class H5Writer:
             try:
                 self._file[field][start:end] = x[:]
                 self._sizes[field] += size
-            except:
-                pdb.set_trace()
+            except Exception as e:
+                raise RuntimeError(
+                    f"failed to write field {field} with slice [{start}, {end})"
+                ) from e
 
     def close(self):
         for field, size in self._sizes.items():


### PR DESCRIPTION
## Summary
- remove leftover `pdb.set_trace()` from `ddpo/utils/hdf5.py`
- raise a runtime error when writing data fails instead of dropping into pdb

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6847ac7fd14c8322a863c1f6a705a5c5